### PR TITLE
Fix/client UI 68

### DIFF
--- a/src/client/java/com/enemaru/screen/ControlPanelScreen.java
+++ b/src/client/java/com/enemaru/screen/ControlPanelScreen.java
@@ -68,36 +68,36 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
         // 街灯 (STREETLIGHT)
         // ==========================
         int lightPercent = screenHandler.getLightPercent() / 100; // 0-10000 → 0-100
-        lightSlider = new PercentageSlider(centerX - sliderWidth / 2 - 90, centerY - 60, sliderWidth, sliderHeight, "light", lightPercent);
+        lightSlider = new PercentageSlider(centerX - sliderWidth / 2 - 100, centerY - 60, sliderWidth, sliderHeight, "light", lightPercent);
         this.addDrawableChild(lightSlider);
-        lightLabelX = centerX - 88;
+        lightLabelX = centerX - 98;
         lightLabelY = centerY - 70;
 
         // ==========================
         // 工場 (FACTORY)
         // ==========================
         int factoryPercent = screenHandler.getFactoryPercent() / 100; // 0-10000 → 0-100
-        factorySlider = new PercentageSlider(centerX - sliderWidth / 2 - 90, centerY - 20, sliderWidth, sliderHeight, "factory", factoryPercent);
+        factorySlider = new PercentageSlider(centerX - sliderWidth / 2 - 100, centerY - 20, sliderWidth, sliderHeight, "factory", factoryPercent);
         this.addDrawableChild(factorySlider);
-        factoryLabelX = centerX - 88;
+        factoryLabelX = centerX - 98;
         factoryLabelY = centerY - 30;
 
         // ==========================
         // 家 (HOUSE)
         // ==========================
         int housePercent = screenHandler.getHousePercent() / 100; // 0-10000 → 0-100
-        houseSlider = new PercentageSlider(centerX - sliderWidth / 2 - 90, centerY + 20, sliderWidth, sliderHeight, "house", housePercent);
+        houseSlider = new PercentageSlider(centerX - sliderWidth / 2 - 100, centerY + 20, sliderWidth, sliderHeight, "house", housePercent);
         this.addDrawableChild(houseSlider);
-        houseLabelX = centerX - 88;
+        houseLabelX = centerX - 98;
         houseLabelY = centerY + 10;
 
         // ==========================
         // 公共施設 (FACILITY)
         // ==========================
         int facilityPercent = screenHandler.getFacilityPercent() / 100; // 0-10000 → 0-100
-        facilitySlider = new PercentageSlider(centerX - sliderWidth / 2 - 90, centerY + 60, sliderWidth, sliderHeight, "facility", facilityPercent);
+        facilitySlider = new PercentageSlider(centerX - sliderWidth / 2 - 100, centerY + 60, sliderWidth, sliderHeight, "facility", facilityPercent);
         this.addDrawableChild(facilitySlider);
-        facilityLabelX = centerX - 88;
+        facilityLabelX = centerX - 98;
         facilityLabelY = centerY + 50;
 
         // ==========================
@@ -110,18 +110,18 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
             EquipmentRequestC2SPayload payload = new EquipmentRequestC2SPayload("train", true);
             ClientPlayNetworking.send(payload);
             updateTrainButtons(true);
-        }).position(centerX - buttonWidth - 90, centerY + 100).size(buttonWidth, buttonHeight).build();
+        }).position(centerX - buttonWidth - 100, centerY + 100).size(buttonWidth, buttonHeight).build();
 
         trainOffButton = ButtonWidget.builder(OFF_TEXT, button -> {
             EquipmentRequestC2SPayload payload = new EquipmentRequestC2SPayload("train", false);
             ClientPlayNetworking.send(payload);
             updateTrainButtons(false);
-        }).position(centerX - 86, centerY + 100).size(buttonWidth, buttonHeight).build();
+        }).position(centerX - 96, centerY + 100).size(buttonWidth, buttonHeight).build();
 
         this.addDrawableChild(trainOnButton);
         this.addDrawableChild(trainOffButton);
 
-        trainLabelX = centerX - 88;
+        trainLabelX = centerX - 98;
         trainLabelY = centerY + 90;
 
         // ==========================
@@ -156,7 +156,7 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
 
     // グラフ用フィールド
     private java.util.List<Integer> energyHistory = new java.util.ArrayList<>();
-    private static final int MAX_HISTORY = 150;
+    private static final int MAX_HISTORY = 300;
 
     @Override
     protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
@@ -435,10 +435,15 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
     private void renderEnergyGraph(DrawContext context, int centerX, int centerY, int barX) {
         // グラフの領域設定
         int graphX = barX;
-        int graphY = centerY + 50;
+        int graphY = centerY + 70;
         int graphWidth = 150;
         int graphHeight = 40;
         int maxEnergy = 3500;
+
+        // グラフタイトル描画
+        String graphTitle = LABEL_ENERGY_AMOUNT.getString();
+        int titleWidth = this.textRenderer.getWidth(graphTitle);
+        context.drawText(this.textRenderer, graphTitle, graphX + (graphWidth - titleWidth) / 2, graphY - 10, 0xFFFFFF, false);
 
         // グラフの背景（薄灰色）
         context.fill(graphX, graphY, graphX + graphWidth, graphY + graphHeight, 0xFF404040);
@@ -480,6 +485,11 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
                 context.fill(x1, y2 - 1, x2 + 1, y2 + 1, lineColor);
             }
         }
+
+        // 縦軸ラベル描画
+        context.drawText(this.textRenderer, "3500kW", graphX - 40, graphY - 5, 0xAAAAAA, false);
+        context.drawText(this.textRenderer, "1750kW", graphX - 38, graphY + graphHeight / 2 - 5, 0xAAAAAA, false);
+        context.drawText(this.textRenderer, "0kW", graphX - 18, graphY + graphHeight, 0xAAAAAA, false);
     }
 
 

--- a/src/client/java/com/enemaru/screen/ControlPanelScreen.java
+++ b/src/client/java/com/enemaru/screen/ControlPanelScreen.java
@@ -278,7 +278,7 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
 
 
         int textX = centerX + 30;
-        int textY = centerY - 50;
+        int textY = centerY - 20;
 
         // ======================
         // Energy Bar
@@ -364,50 +364,6 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
         int barH = barHeight;
 
         renderPredicted(context, mouseX, mouseY, baseX, barX, barH, surplusBarY, displayedEnergy, train);
-
-        // ======================
-        // 他情報表示
-        // ======================
-        // 表の左上座標
-        int tableX = textX + 20;
-        int tableY = textY + 90;
-
-        // 列幅
-        int col1Width = 50; // ラベル列
-        int col2Width = 40; // 状態列
-        int rowHeight = this.textRenderer.fontHeight + 4;  // フォント高さ + 余白
-
-        // ヘッダー
-        context.drawText(this.textRenderer, HEADER_DEVICE, tableX + 2, tableY + 2, 0xFFFFAA00, false);
-        context.drawText(this.textRenderer, HEADER_STATE, tableX + col1Width + 2, tableY + 2, 0xFFFFAA00, false);
-
-        // 線の色
-        int lineColor = 0xFFAAAAAA;
-
-        // ヘッダー下の線
-        context.fill(tableX, tableY + rowHeight, tableX + col1Width + col2Width, tableY + rowHeight + 1, lineColor);
-
-        // データ行（Trainのみ）
-        String[][] rows = {
-                {LABEL_TRAIN.getString(), train ? "On" : "Off"}
-        };
-
-        for (int i = 0; i < rows.length; i++) {
-            int y = tableY + rowHeight * (i + 1);
-
-            // ラベル列
-            context.drawText(this.textRenderer, rows[i][0], tableX + 2, y + 2, 0xFFFFFF, false);
-
-            // 状態列
-            context.drawText(this.textRenderer, rows[i][1], tableX + col1Width + 2, y + 2, 0xFFFFFF, false);
-
-            // 行下線
-            context.fill(tableX, y + rowHeight -1, tableX + col1Width + col2Width, y + rowHeight, lineColor);
-
-            // 列の区切り線（垂直）
-            context.fill(tableX + col1Width - 3, y - 13, tableX + col1Width - 2, y + rowHeight, lineColor);
-        }
-
 
         drawMouseoverTooltip(context, mouseX, mouseY);
     }

--- a/src/client/java/com/enemaru/screen/ControlPanelScreen.java
+++ b/src/client/java/com/enemaru/screen/ControlPanelScreen.java
@@ -154,9 +154,10 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
 
     private boolean isThermalSynced = false;
 
-    // グラフ用フィールド
-    private java.util.List<Integer> energyHistory = new java.util.ArrayList<>();
-    private static final int MAX_HISTORY = 300;
+    // 描画用フィールド
+    private int displayedEnergy = 0;
+    private int displayedSurplus = 0;
+    private boolean hasSetInitialDisplayed = false;
 
     @Override
     protected void drawBackground(DrawContext context, float delta, int mouseX, int mouseY) {
@@ -363,13 +364,7 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
         // ======================
         // 電力量の履歴記録
         // ======================
-        if (energyHistory == null) {
-            energyHistory = new java.util.ArrayList<>();
-        }
-        if (energyHistory.size() >= MAX_HISTORY) {
-            energyHistory.remove(0);
-        }
-        energyHistory.add((int)displayedEnergy);
+        ControlPanelScreenHandler.addEnergyHistory((int)displayedEnergy);
 
         // ======================
         // 電力量グラフ描画
@@ -386,11 +381,6 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
 
         drawMouseoverTooltip(context, mouseX, mouseY);
     }
-
-    // 描画用フィールド
-    private int displayedEnergy = 0;
-    private int displayedSurplus = 0;
-    private boolean hasSetInitialDisplayed = false;
 
     // ======================
     // 予測バー描画用メソッド
@@ -463,12 +453,17 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
         }
 
         // 折れ線グラフを描画
+        java.util.List<Integer> energyHistory = ControlPanelScreenHandler.getEnergyHistory();
         if (energyHistory.size() > 1) {
             int lineColor = 0xFF00FF00; // 緑色
 
             for (int i = 0; i < energyHistory.size() - 1; i++) {
-                int x1 = graphX + (int)((double)i / MAX_HISTORY * graphWidth);
-                int x2 = graphX + (int)((double)(i + 1) / MAX_HISTORY * graphWidth);
+                int x1 = graphX + (int)((double)i / ControlPanelScreenHandler.MAX_HISTORY * graphWidth);
+                int x2 = graphX + (int)((double)(i + 1) / ControlPanelScreenHandler.MAX_HISTORY * graphWidth);
+
+                // X座標をグラフ範囲内にクリップ
+                x1 = Math.max(graphX, Math.min(graphX + graphWidth, x1));
+                x2 = Math.max(graphX, Math.min(graphX + graphWidth, x2));
 
                 int energy1 = energyHistory.get(i);
                 int energy2 = energyHistory.get(i + 1);
@@ -491,8 +486,6 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
         context.drawText(this.textRenderer, "1750kW", graphX - 38, graphY + graphHeight / 2 - 5, 0xAAAAAA, false);
         context.drawText(this.textRenderer, "0kW", graphX - 18, graphY + graphHeight, 0xAAAAAA, false);
     }
-
-
     private void drawCenteredLabel(DrawContext context, String text, int cx, int cy) {
         int w = this.textRenderer.getWidth(text);
         context.drawText(this.textRenderer, text, cx - w / 2, cy, 0xFFFFFF, false);

--- a/src/client/java/com/enemaru/screen/ControlPanelScreen.java
+++ b/src/client/java/com/enemaru/screen/ControlPanelScreen.java
@@ -440,7 +440,7 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
 
         // グリッド線を描画（薄灰色）
         int gridColor = 0xFF555555;
-        int gridSpacing = 30;
+        int gridSpacing = (int)((double)graphWidth / (ControlPanelScreenHandler.MAX_HISTORY / 300.0));
 
         // 縦のグリッド線
         for (int x = graphX; x <= graphX + graphWidth; x += gridSpacing) {
@@ -475,9 +475,8 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
                 y1 = Math.max(graphY, Math.min(graphY + graphHeight, y1));
                 y2 = Math.max(graphY, Math.min(graphY + graphHeight, y2));
 
-                // 線を描画（太さ2ピクセル）
-                context.fill(x1, y1, x2 + 1, y1 + 2, lineColor);
-                context.fill(x1, y2 - 1, x2 + 1, y2 + 1, lineColor);
+                // 線を描画（太さ1ピクセル）
+                context.fill(x1, y1, x2 + 1, y1 + 1, lineColor);
             }
         }
 

--- a/src/client/java/com/enemaru/screen/ControlPanelScreen.java
+++ b/src/client/java/com/enemaru/screen/ControlPanelScreen.java
@@ -1,9 +1,10 @@
 package com.enemaru.screen;
 
-import com.enemaru.gui.ThermalSlider;
 import com.enemaru.gui.PercentageSlider;
+import com.enemaru.gui.ThermalSlider;
 import com.enemaru.networking.payload.EquipmentRequestC2SPayload;
 import com.enemaru.screenhandler.ControlPanelScreenHandler;
+
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -173,33 +174,33 @@ public class ControlPanelScreen extends HandledScreen<ScreenHandler> {
 
         // ラベル描画
         drawCenteredLabel(context, LABEL_LIGHT.getString(), lightLabelX, lightLabelY);
-        // Light スライダー下の値表示
+        // Light スライダー右の値表示
         String lightValueText = lightSlider.getPercent() + "%";
-        int lightValueX = lightSlider.getX() + lightSlider.getWidth() / 2;
-        int lightValueY = lightSlider.getY() + lightSlider.getHeight() + 2;
-        context.drawText(this.textRenderer, lightValueText, lightValueX - this.textRenderer.getWidth(lightValueText) / 2, lightValueY, 0xFFFFFF, false);
+        int lightValueX = lightSlider.getX() + lightSlider.getWidth() + 5;
+        int lightValueY = lightSlider.getY() + (lightSlider.getHeight() - this.textRenderer.fontHeight) / 2;
+        context.drawText(this.textRenderer, lightValueText, lightValueX, lightValueY, 0xFFFFFF, false);
 
         drawCenteredLabel(context, LABEL_TRAIN.getString(), trainLabelX, trainLabelY);
         drawCenteredLabel(context, LABEL_FACTORY.getString(), factoryLabelX, factoryLabelY);
-        // Factory スライダー下の値表示
+        // Factory スライダー右の値表示
         String factoryValueText = factorySlider.getPercent() + "%";
-        int factoryValueX = factorySlider.getX() + factorySlider.getWidth() / 2;
-        int factoryValueY = factorySlider.getY() + factorySlider.getHeight() + 2;
-        context.drawText(this.textRenderer, factoryValueText, factoryValueX - this.textRenderer.getWidth(factoryValueText) / 2, factoryValueY, 0xFFFFFF, false);
+        int factoryValueX = factorySlider.getX() + factorySlider.getWidth() + 5;
+        int factoryValueY = factorySlider.getY() + (factorySlider.getHeight() - this.textRenderer.fontHeight) / 2;
+        context.drawText(this.textRenderer, factoryValueText, factoryValueX, factoryValueY, 0xFFFFFF, false);
 
         drawCenteredLabel(context, LABEL_HOUSE.getString(), houseLabelX, houseLabelY);
-        // House スライダー下の値表示
+        // House スライダー右の値表示
         String houseValueText = houseSlider.getPercent() + "%";
-        int houseValueX = houseSlider.getX() + houseSlider.getWidth() / 2;
-        int houseValueY = houseSlider.getY() + houseSlider.getHeight() + 2;
-        context.drawText(this.textRenderer, houseValueText, houseValueX - this.textRenderer.getWidth(houseValueText) / 2, houseValueY, 0xFFFFFF, false);
+        int houseValueX = houseSlider.getX() + houseSlider.getWidth() + 5;
+        int houseValueY = houseSlider.getY() + (houseSlider.getHeight() - this.textRenderer.fontHeight) / 2;
+        context.drawText(this.textRenderer, houseValueText, houseValueX, houseValueY, 0xFFFFFF, false);
 
         drawCenteredLabel(context, LABEL_FACILITY.getString(), facilityLabelX, facilityLabelY);
-        // Facility スライダー下の値表示
+        // Facility スライダー右の値表示
         String facilityValueText = facilitySlider.getPercent() + "%";
-        int facilityValueX = facilitySlider.getX() + facilitySlider.getWidth() / 2;
-        int facilityValueY = facilitySlider.getY() + facilitySlider.getHeight() + 2;
-        context.drawText(this.textRenderer, facilityValueText, facilityValueX - this.textRenderer.getWidth(facilityValueText) / 2, facilityValueY, 0xFFFFFF, false);
+        int facilityValueX = facilitySlider.getX() + facilitySlider.getWidth() + 5;
+        int facilityValueY = facilitySlider.getY() + (facilitySlider.getHeight() - this.textRenderer.fontHeight) / 2;
+        context.drawText(this.textRenderer, facilityValueText, facilityValueX, facilityValueY, 0xFFFFFF, false);
 
         // ネットワーク受信値
         int energy = screenHandler.getGeneratedEnergy();

--- a/src/main/java/com/enemaru/commands/SessionCommand.java
+++ b/src/main/java/com/enemaru/commands/SessionCommand.java
@@ -7,6 +7,7 @@ import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import com.enemaru.power.PowerNetwork;
+import com.enemaru.screenhandler.ControlPanelScreenHandler;
 import net.minecraft.server.world.ServerWorld;
 
 public final class SessionCommand {
@@ -20,6 +21,8 @@ public final class SessionCommand {
                                     ServerWorld world = context.getSource().getWorld();
                                     PowerNetwork network = PowerNetwork.get(world);
                                     network.setSessionId(id);
+                                    // グラフの履歴をクリア
+                                    ControlPanelScreenHandler.clearEnergyHistory();
                                     return Command.SINGLE_SUCCESS;
                                 })
                         )

--- a/src/main/java/com/enemaru/screenhandler/ControlPanelScreenHandler.java
+++ b/src/main/java/com/enemaru/screenhandler/ControlPanelScreenHandler.java
@@ -7,6 +7,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.screen.ArrayPropertyDelegate;
 import net.minecraft.screen.PropertyDelegate;
 import net.minecraft.screen.ScreenHandler;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ControlPanelScreenHandler extends ScreenHandler {
     public static final int PROP_ENERGY = 0;
@@ -19,6 +21,11 @@ public class ControlPanelScreenHandler extends ScreenHandler {
     public static final int PROP_FACILITY = 7;
     public static final int PROP_THERMAL = 8;
     public static final int NUM_PROPS = 9;
+
+    // グラフ用の静的リスト
+    public static final List<Integer> energyHistory = new ArrayList<>();
+    public static final int MAX_HISTORY = 600;
+
     private final PropertyDelegate propertyDelegate;
 
     /**
@@ -84,6 +91,23 @@ public class ControlPanelScreenHandler extends ScreenHandler {
     }
     public int getFacilityPercent() {
         return propertyDelegate.get(PROP_FACILITY);
+    }
+    
+    /**
+     * エネルギー履歴を追加
+     */
+    public static void addEnergyHistory(int energy) {
+        if (energyHistory.size() >= MAX_HISTORY) {
+            energyHistory.remove(0);
+        }
+        energyHistory.add(energy);
+    }
+    
+    /**
+     * エネルギー履歴を取得
+     */
+    public static List<Integer> getEnergyHistory() {
+        return energyHistory;
     }
 
     @Override

--- a/src/main/java/com/enemaru/screenhandler/ControlPanelScreenHandler.java
+++ b/src/main/java/com/enemaru/screenhandler/ControlPanelScreenHandler.java
@@ -24,7 +24,7 @@ public class ControlPanelScreenHandler extends ScreenHandler {
 
     // グラフ用の静的リスト
     public static final List<Integer> energyHistory = new ArrayList<>();
-    public static final int MAX_HISTORY = 600;
+    public static final int MAX_HISTORY = 2400;
 
     private final PropertyDelegate propertyDelegate;
 

--- a/src/main/java/com/enemaru/screenhandler/ControlPanelScreenHandler.java
+++ b/src/main/java/com/enemaru/screenhandler/ControlPanelScreenHandler.java
@@ -110,6 +110,13 @@ public class ControlPanelScreenHandler extends ScreenHandler {
         return energyHistory;
     }
 
+    /**
+     * エネルギー履歴をクリア
+     */
+    public static void clearEnergyHistory() {
+        energyHistory.clear();
+    }
+
     @Override
     public boolean canUse(PlayerEntity player) {
         return true;


### PR DESCRIPTION
クライアントUIの変更
・火力発電バーを左下から右上に変更
・電車ボタンの位置変更および、各スライダーの間隔調節
・状態表示用の表を削除し、受信電力量を表示できる折れ線グラフを新たに追加
・余裕電力バーを値に応じて表示が緑から赤になるように変更
・セッションID変更時にグラフの履歴を削除する機能を追加